### PR TITLE
Fix skip parser handling of `rep_`

### DIFF
--- a/prcc.scm
+++ b/prcc.scm
@@ -539,7 +539,7 @@
   (define (rep_ p #!key (skip (<s*>)))
     (check-procedure 'rep_ p)
     (check-procedure 'rep_ skip)
-    (<or> (rep+_ p skip)
+    (<or> (rep+_ p skip: skip)
 	  (act (zero) (lambda (o) `()))))
   (define <*_> rep_)
 

--- a/tests/rep.scm
+++ b/tests/rep.scm
@@ -20,7 +20,10 @@
 
 (test `() (parse-string "b" p0))
 
+(define p1 (<*_> (char #\a) skip: (char #\,)))
+
+(test (list "a" "a" "a" "a" "a") (parse-string "a,a,a,a,a" p1))
+
+(test `() (parse-string "b" p1))
+
 (test-end "rep_")
-
-
-


### PR DESCRIPTION
It didn't pass the skip parser as a `skip:` keyword argument when calling `rep+_`, but as a regular positional argument, causing the skip parser to be ignored, using the default of whitespace in all cases.

This also adds a regression test.
